### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added new "GitHub Skills" activity to the activities dictionary
- Description mentions GitHub Certifications program and college application benefits
- Schedule: Wednesdays, 3:30 PM - 5:00 PM  
- Capacity: 25 participants
- Ready for immediate student registrations

## Fixes
Closes #6

## Context
This is time-sensitive as registrations close by end of week. Students have been unable to sign up since the principal's announcement.

## Testing
- ✅ Activity appears in activities list
- ✅ Students can register for the activity
- ✅ Maintains existing functionality for all other activities